### PR TITLE
Correct name of executable in command help text.

### DIFF
--- a/src/gophish_init/gophish_init.py
+++ b/src/gophish_init/gophish_init.py
@@ -3,8 +3,8 @@
 """Gophish_init is a configuration utility for Gophish.
 
 Usage:
-  gophish_init [--log-level=LEVEL] [--url=URL] API_KEY
-  gophish_init (-h | --help)
+  gophish-init [--log-level=LEVEL] [--url=URL] API_KEY
+  gophish-init (-h | --help)
 
 Options:
   -h --help              Show this message.

--- a/src/gophish_init/gophish_init.py
+++ b/src/gophish_init/gophish_init.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-"""Gophish_init is a configuration utility for Gophish.
+"""Gophish-init is a configuration utility for Gophish.
 
 Usage:
   gophish-init [--log-level=LEVEL] [--url=URL] API_KEY


### PR DESCRIPTION
Fixing a typo in the help text.  But this was part of a larger molecule-test-snafu. (ask @dav3r )

See: 
- https://stackoverflow.com/questions/19097057/pip-e-no-magic-underscore-to-dash-replacement
- https://mail.python.org/pipermail/distutils-sig/2011-August/017935.html
- https://mail.python.org/pipermail/distutils-sig/2011-August/017936.html