### PR TITLE
Update to use latest gophish

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The following `gophish-tools` helper scripts are available in the
 
 Connect to the `gophish` admin web interface at:
 [https://localhost:3333](https://localhost:3333).
-The default credentials are `admin`, `gophish`.
+The default credentials are `admin`, `gophish1`.
 
 Once the composition is running, `gophish` will need to be
 configured to talk to `mailhog` and `postfix`. Create new

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The following `gophish-tools` helper scripts are available in the
 
 Connect to the `gophish` admin web interface at:
 [https://localhost:3333](https://localhost:3333).
-The default credentials are `admin`, `gophish1`.
+The default credentials are `admin`, `gophish`.
 
 Once the composition is running, `gophish` will need to be
 configured to talk to `mailhog` and `postfix`. Create new

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ secrets:
 
 services:
   gophish:
-    image: cisagov/gophish:0.0.5
+    image: cisagov/gophish:latest
     init: true
     restart: always
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,9 @@ secrets:
 
 services:
   gophish:
-    image: cisagov/gophish:latest
+    # Reminder: cisagov/gophish Docker images are created with
+    # cisagov/gophish-docker, not cisagov/gophish!
+    image: cisagov/gophish:0.11.0-cisa.1
     init: true
     restart: always
     ports:

--- a/src/gophish_init/_version.py
+++ b/src/gophish_init/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "0.0.7"
+__version__ = "0.1.0"


### PR DESCRIPTION


## 🗣 Description ##

Updated `docker-compose.yml` to pull latest `cisagov/gophish`

## 💭 Motivation and context ##

Previous version was hardcoded to `0.7.1`, this change moves it to `cisagov/gophish:latest`. At this time, the latest version is `0.11`, so we were a little out of date. 

## 🧪 Review Guidance ##

Navigate to the `pca-gophish-composition` directory and run the `docker-compose up` command. 

Once the service is running, navigate to the address and login with the `admin` credentials outlined in the updated `README`. 

Under Account Settings, verify that the current version is `0.11.0`
