### PR TITLE
Remove unnecessary quotes around port numbers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,12 +69,12 @@ services:
       # the default network subnet defined below.
       - RELAY_IP=172.16.202.0/24
     ports:
-      - target: "25"
-        published: "1025"
+      - target: 25
+        published: 1025
         protocol: tcp
         mode: host
-      - target: "587"
-        published: "1587"
+      - target: 587
+        published: 1587
         protocol: tcp
         mode: host
     secrets:


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes some unnecessary quotes around port numbers.

## 💭 Motivation and context ##

These quotes are unnecessary, and they lead to some needlessly complicated regex expressions in [cisagov/pca-gophish-composition-packer](cisagov/pca-gophish-composition-packer).  This is a sister PR of cisagov/pca-gophish-composition-packer#72, and the two PRs should be merged together.

## 🧪 Testing ##

All automated tests pass.  I also built a new staging AMI with these changes, deployed it to `env6-staging`, and verified that it functions as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.