### PR TITLE
Update code to use the "docker compose" syntax vice "docker-compose"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Creates a Docker composition containing instances of:
 A sample [docker composition](docker-compose.yml) is included
 in this repository.
 
-To start the composition use the command: `docker-compose up`
+To start the composition use the command: `docker compose up`
 
 It's normal for the `gophish-tools` container to exit shortly after startup;
 it is included in this composition as a convenience for phishing operators.

--- a/gophish-tools/complete_campaign.sh
+++ b/gophish-tools/complete_campaign.sh
@@ -22,14 +22,14 @@ source "$SCRIPTS_DIR/gophish_common.sh"
 CAMPAIGN_ID=$1
 
 # Disable errexit to allow error-handling within get_gophish_api_key
-# and for the subsequent docker-compose call to gophish-complete
+# and for the subsequent docker compose call to gophish-complete
 set +o errexit
 
 # Fetch GoPhish API key
 API_KEY=$(get_gophish_api_key)
 
 # Run gophish-complete in the Docker composition
-docker-compose -f "$GOPHISH_COMPOSITION" run --rm \
+docker compose -f "$GOPHISH_COMPOSITION" run --rm \
   gophish-tools gophish-complete "--campaign=$CAMPAIGN_ID" \
   "$GOPHISH_URL" "$API_KEY"
 complete_rc="$?"

--- a/gophish-tools/export_assessment.sh
+++ b/gophish-tools/export_assessment.sh
@@ -24,14 +24,14 @@ ASSESSMENT_ID=$1
 GOPHISH_WRITABLE_DIR="/var/pca/pca-gophish-composition/data"
 
 # Disable errexit to allow error-handling within get_gophish_api_key
-# and for the subsequent docker-compose call to gophish-export
+# and for the subsequent docker compose call to gophish-export
 set +o errexit
 
 # Fetch GoPhish API key
 API_KEY=$(get_gophish_api_key)
 
 # Run gophish-export in the Docker composition
-docker-compose -f "$GOPHISH_COMPOSITION" run --rm \
+docker compose -f "$GOPHISH_COMPOSITION" run --rm \
   --volume "$GOPHISH_WRITABLE_DIR":/home/cisa \
   gophish-tools gophish-export "$ASSESSMENT_ID" "$GOPHISH_URL" "$API_KEY"
 export_rc="$?"

--- a/gophish-tools/gophish_common.sh
+++ b/gophish-tools/gophish_common.sh
@@ -12,7 +12,7 @@ GOPHISH_URL="https://gophish:3333"
 
 function get_gophish_api_key {
   # Fetch GoPhish API key
-  API_KEY=$(docker-compose -f "$GOPHISH_COMPOSITION" exec -T gophish get-api-key)
+  API_KEY=$(docker compose -f "$GOPHISH_COMPOSITION" exec -T gophish get-api-key)
   api_key_rc="$?"
   if [ "$api_key_rc" -ne 0 ]; then
     echo "ERROR: Failed to obtain GoPhish API key from Docker composition."

--- a/gophish-tools/import_assessment.sh
+++ b/gophish-tools/import_assessment.sh
@@ -24,14 +24,14 @@ ASSESSMENT_FILE_BASE=$(basename "$ASSESSMENT_FILE")
 ASSESSMENT_FILE_DIR=$(readlink -f "$ASSESSMENT_FILE" | xargs dirname)
 
 # Disable errexit to allow error-handling within get_gophish_api_key
-# and for the subsequent docker-compose call to gophish-import
+# and for the subsequent docker compose call to gophish-import
 set +o errexit
 
 # Fetch GoPhish API key
 API_KEY=$(get_gophish_api_key)
 
 # Run gophish-import in the Docker composition
-docker-compose -f "$GOPHISH_COMPOSITION" run --rm \
+docker compose -f "$GOPHISH_COMPOSITION" run --rm \
   --volume "$ASSESSMENT_FILE_DIR":/home/cisa gophish-tools \
   gophish-import "$ASSESSMENT_FILE_BASE" "$GOPHISH_URL" "$API_KEY"
 import_rc="$?"

--- a/gophish-tools/test_assessment.sh
+++ b/gophish-tools/test_assessment.sh
@@ -22,14 +22,14 @@ source "$SCRIPTS_DIR/gophish_common.sh"
 ASSESSMENT_ID=$1
 
 # Disable errexit to allow error-handling within get_gophish_api_key
-# and for the subsequent docker-compose call to gophish-test
+# and for the subsequent docker compose call to gophish-test
 set +o errexit
 
 # Fetch GoPhish API key
 API_KEY=$(get_gophish_api_key)
 
 # Run gophish-test in the Docker composition
-docker-compose -f "$GOPHISH_COMPOSITION" run --rm \
+docker compose -f "$GOPHISH_COMPOSITION" run --rm \
   gophish-tools gophish-test "$ASSESSMENT_ID" "$GOPHISH_URL" "$API_KEY"
 test_rc="$?"
 if [ "$test_rc" -eq 0 ]; then

--- a/src/gophish_init/_version.py
+++ b/src/gophish_init/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/src/gophish_init/_version.py
+++ b/src/gophish_init/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "0.2.1"
+__version__ = "0.2.1-rc.1"

--- a/src/gophish_init/_version.py
+++ b/src/gophish_init/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "0.2.1-rc.1"
+__version__ = "0.2.1"


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the code to use the `docker compose` syntax instead of the `docker-compose` syntax.

## 💭 Motivation and context ##

The `docker compose` syntax is the preferred (and only correct) syntax after the changes in cisagov/ansible-role-docker#60.

## 🧪 Testing ##

Automated testing passes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Finalize version.

## ✅ Post-merge checklist ##

- [x] Add a tag or create a release.
