### PR TITLE
Update name of package from `gophish_init` to `gophish-init`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def get_version(version_file):
 
 
 setup(
-    name="gophish_init",
+    name="gophish-init",
     # Versions should comply with PEP440
     version=get_version("src/gophish_init/_version.py"),
     description="GoPhish initialization library",
@@ -87,7 +87,7 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
     ],
     # What does your project relate to?
-    keywords="gophish_init",
+    keywords="gophish-init",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     py_modules=[splitext(basename(path))[0] for path in glob("src/*.py")],

--- a/src/gophish_init/_version.py
+++ b/src/gophish_init/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "0.5.0"
+__version__ = "0.5.0-rc.1"

--- a/src/gophish_init/_version.py
+++ b/src/gophish_init/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "0.5.0-rc.1"
+__version__ = "0.5.0"

--- a/src/gophish_init/_version.py
+++ b/src/gophish_init/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "0.4.0"
+__version__ = "0.5.0"


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the name of the Python package from `gophish_init` to `gophish-init`.

## 💭 Motivation and context ##

We discovered in cisagov/ansible-role-pca-gophish-composition#52 that older versions of `pip` normalize the package name (converting underscores to hyphens) while at least one newer version does not.  To ensure that the package name is not modified by `pip` and has the expected value, we change it to its normalized form.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Finalize version.

## ✅ Post-merge checklist ##

- [x] Create a release.
