### PR TITLE
Fix broken reinstall on Fedora 39, Fedora 40, and Ubuntu 24.04

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,13 @@ setup(
     package_dir={"": "src"},
     py_modules=[splitext(basename(path))[0] for path in glob("src/*.py")],
     include_package_data=True,
-    install_requires=["docopt", "gophish", "setuptools >= 24.2.0"],
+    # gophish requires six==1.15.0, whereas setuptools>=71 requires
+    # six==1.16.0.  The installation of setuptools>=71 ends up being a problem
+    # when attempting to reinstall this package, since then setuptools cannot
+    # be imported.  This is precisely what happens during idempotence testing
+    # of cisagov/ansible-role-pca-gophish-composition, so we must insist that
+    # only setuptools<71 is installed.
+    install_requires=["docopt", "gophish", "setuptools >=24.2.0,<71"],
     extras_require={
         "test": [
             "coverage",

--- a/src/gophish_init/_version.py
+++ b/src/gophish_init/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this module."""
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"


### PR DESCRIPTION
## 🗣 Description ##

This pull request fixes broken reinstalls on Fedora 39, Fedora 40, and Ubuntu 24.04 by ensuring that `setuptools>=71` is not installed.

## 💭 Motivation and context ##

`gophish` requires `six==1.15.0`, whereas `setuptools>=71` requires `six==1.16.0`.  The installation of `setuptools>=71` ends up being a problem when attempting to reinstall this package, since then `setuptools` cannot be imported.  [This is precisely what happens](https://github.com/cisagov/ansible-role-pca-gophish-composition/actions/runs/10515698006/job/29136352452#step:11:335) during idempotence testing of [cisagov/ansible-role-pca-gophish-composition](https://github.com/cisagov/ansible-role-pca-gophish-composition), so we must insist that only `setuptools<71` is installed.

## 🧪 Testing ##

All automated tests pass, for this PR as well as for cisagov/ansible-role-pca-gophish-composition#??.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Finalize version.

## ✅ Post-merge checklist ##

- [x] Create a release.
