### PR TITLE
Add an upper bound for the Python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,10 @@ setup(
         # "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: Implementation :: CPython",
     ],
-    python_requires=">=3.9",
+    # On Python 3.12 and later the version of urllib3 required by
+    # gophish fails to import with:
+    # ModuleNotFoundError: No module named 'urllib3.packages.six.moves'
+    python_requires=">=3.9,<3.12",
     # What does your project relate to?
     keywords="gophish-init",
     packages=find_packages(where="src"),


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds an upper bound to the Python version listed in the `setup.py` file.

## 💭 Motivation and context ##

On Python 3.12 and later the version of `urllib3` required by `gophish` fails to import with:
```ModuleNotFoundError: No module named 'urllib3.packages.six.moves'```.  Adding the upper bound will prevent this package from being installed where it will not run.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

- [x] Finalize version.

## ✅ Post-merge checklist ##

- [ ] Create a release (necessary if and only if the version was bumped).
